### PR TITLE
Remove Leap section from English resources

### DIFF
--- a/pages/resources-and-programs/silver-ed/ingles.mdx
+++ b/pages/resources-and-programs/silver-ed/ingles.mdx
@@ -16,10 +16,3 @@ Más información en [https://silver.dev/english](https://silver.dev/english).
 
 <Embed src="https://www.youtube.com/embed/7l9F0sb9-Uo?si=IakWVdj_RKHABB13"/>
 
-
-## 🇺🇸 Leap - Prácticas de inglés hablado para programadores (niveles A2+ a B2) - 30% OFF con el código SILVER 
-
-Leap es una escuela de inglés para programadores que combina conversaciones guiadas y prácticas con otros estudiantes y feedback personalizado después de cada sesión. 
-
-Link: [Leap](https://lp.leap.school/?utm_source=silver.dev&utm_medium=referral&utm_campaign=SILVERED)
-


### PR DESCRIPTION
Removes the Leap English promotional section from the English resources page.